### PR TITLE
👟 Switch back to linux based testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-os: osx
+language: minimal
 if: branch = master OR type = pull_request
 sudo: required
 install:
-  - brew install shellcheck
+  - sudo apt-get install shellcheck
 script:
   - ./script/bootstrap --debug && ./script/test


### PR DESCRIPTION
TravisCI osx environment is significantly slower than the default, and the only macOS specific command I have at the moment is gated under a uname check.